### PR TITLE
Mitigation Round Code and Example

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "trojai-round-generation-private"]
-	path = trojai-round-generation-private
-	url = https://github.com/usnistgov/trojai-round-generation-private.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "trojai-round-generation-private"]
+	path = trojai-round-generation-private
+	url = https://github.com/usnistgov/trojai-round-generation-private.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM pytorch/pytorch:2.1.2-cuda11.8-cudnn8-runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+WORKDIR /trojai-example
+COPY . . 
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git ffmpeg libsm6 libxext6
+RUN pip install -r requirements.txt
+RUN pip install -r ./BackdoorBox-APL/requirements.txt
+RUN pip install -e ./BackdoorBox-APL
+RUN pip install -e ./mitigationround
+
+ENTRYPOINT ["python3", "example_trojai_mitigation.py", "--metaparameters", "metaparameters.yml"]

--- a/example_trojai_mitigation.py
+++ b/example_trojai_mitigation.py
@@ -1,0 +1,167 @@
+import os
+
+import configargparse
+import torch
+from torch import nn
+import torchvision
+from torchvision.models import resnet50
+from torchvision import transforms
+from tqdm import tqdm
+from PIL import Image
+
+from trojai_mitigation_round.mitigations import FineTuningTrojai
+
+# Probably needs to be a better way to define the transforms for a given dataset?
+transform_train = transforms.Compose([
+    transforms.RandomCrop(32, padding=4),
+    transforms.RandomHorizontalFlip(),
+    transforms.ToTensor(),
+    transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+])
+
+transform_test = transforms.Compose([
+    transforms.ToTensor(),
+    transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
+])
+
+
+def prepare_mitigation(args):
+    """Given the command line args, construct and return a subclass of the TrojaiMitigation class
+
+    :param args: The command line args
+    :return: A subclass of TrojaiMitigation that can implement a given mitigtaion technique
+    """
+    # Get required classes for loss and optimizer dynamically
+    loss_class = getattr(torch.nn, args.loss_class)
+    optim_class = getattr(torch.optim, args.optimizer_class)
+
+    print(f"Using {loss_class} for ft loss")
+    print(f"Using {optim_class} for ft optimizer")
+
+    # Construct defense with args
+    mitigation = FineTuningTrojai(
+        loss_cls=loss_class,
+        optim_cls=optim_class,
+        lr=args.learning_rate,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        device=args.device,
+    )
+    return mitigation
+
+
+def prepare_model(path, num_classes, device):
+    """Prepare and load a model defined at a path
+
+    :param path: the path to a pytorch state dict model that will be loaded
+    :param num_classes: The number of classes in the dataset
+    :param device: Either cpu or cuda to push the device onto
+    :return: A pytorch model
+    """
+    model = resnet50()
+    model.fc = nn.Linear(model.fc.in_features, num_classes)
+    model.load_state_dict(torch.load(path))
+    model = model.to(device=device)
+    return model
+
+
+def mitigate_model(model, dataset_path, output_dir):
+    """Given the a torch model and a path to a dataset that may or may not contain clean/poisoned examples, output a mitigated
+    model into the output directory.
+
+    :param model: Pytorch model to be mitigated
+    :param dataset_path: The path to a dataset that may/may not contain poisoned examples
+    :param output_dir: The directory where the mitigated model's state dict is to be saved to.
+    """
+    dataset = torchvision.datasets.DatasetFolder(dataset_path, loader=Image.open, extensions=("png",), transform=transform_train)
+    mitigated_model = mitigation.mitigate_model(model, dataset)
+    os.makedirs(output_dir, exist_ok=True)
+    torch.save(mitigated_model.state_dict, os.path.join(output_dir, "model.pt"))
+
+
+def test_model(model, mitigation, testset_path, batch_size, num_workers, device):
+    """Tests a given model on a given dataset, using a given mitigation's pre and post processing
+    before and after interfence. 
+
+    :param model: Pytorch model to test
+    :param mitigation: The mitigation technique we're using
+    :param testset_path: The path to a testset that may or may not be poisoned
+    :param batch_size: Batch size for the dataloader
+    :param num_workers: The number of workers to use for the dataloader
+    :param device: cuda or cpu device
+    :return: dictionary of the results with the labels and logits
+    """
+    testset = torchvision.datasets.DatasetFolder(testset_path, loader=Image.open, extensions=("png",), transform=transform_test)
+    dataloader = torch.utils.data.DataLoader(testset, batch_size=batch_size, num_workers=num_workers)
+    
+    model.eval()
+    all_logits = torch.tensor([])
+    all_labels = torch.tensor([])
+    # drop the label
+    for x, y in tqdm(dataloader):
+        preprocess_x, info = mitigation.preprocess_transform(x)
+        output_logits = model(preprocess_x.to(device)).detach().cpu()
+        final_logits = mitigation.postprocess_transform(output_logits.detach().cpu(), info)
+
+        all_logits = torch.cat([all_logits, final_logits], axis=0)
+        all_labels = torch.cat([all_labels, y], axis=0)
+    
+    return {
+        'pred_logits': all_logits,
+        'labels': all_labels
+    }
+
+
+if __name__ == "__main__":
+    # configargparse allows a YAML to define certain args 
+    parser = configargparse.ArgParser(
+        config_file_parser_class=configargparse.YAMLConfigFileParser
+    )
+
+    # Any CLI args not defined in either the command line or config will be None
+    parser.add_argument(
+        "--metaparameters",
+        is_config_file_arg=True,
+        type=str,
+        required=True,
+        help="Required YAML metaparameters file",
+    )
+
+    # The two entrypoints; the mitigation stage and the testing stage
+    parser.add_argument('--mitigate', action='store_true', help='Flag that asserts we are conducting mitigation on the given model')
+    parser.add_argument('--test', action='store_true', help='Flag that asserts we are conducting testing on the given model')
+    parser.add_argument('--model_filepath', type=str, default="./model.pt", help="File path to the model that will be either mitigated or tested ")
+
+    # Other defined paths
+    parser.add_argument('--dataset', type=str, default=None, help="If doing training, filepath to the dataset that contains the sample data dataset. If doing test, filepath to a dataset that could either be poisoned or clean.")
+    parser.add_argument('--scratch_dirpath', type=str, default="./scratch", help="File path to the folder where a scratch space is located.")
+    parser.add_argument('--output_dirpath', type=str, default="./out", help="File path to where the output will be dumped")
+
+    # Performer-specific hyperparameters overwritten by metaparameters.yml (but defined here)
+    parser.add_argument('--optimizer_class', type=str, help='Class to use for optimizer for fine tuning')
+    parser.add_argument('--loss_class', type=str, help='Class to use for loss for fine tuning')
+    parser.add_argument('--learning_rate', type=float, help='Learning rate to use for fine tuning')
+    parser.add_argument('--epochs', type=int, help='Count of epochs to do fine tuning for')
+
+    # Misc args used across all mitigations
+    parser.add_argument('--batch_size', type=int, default=32, help="The batch size that the technique would use for data loading")
+    parser.add_argument('--device', type=str, default='cuda', help="The device to use")
+    parser.add_argument('--num_workers', type=int, default=1, help="The number of CPU processes to use to load data")
+    parser.add_argument('--num_classes', type=int, help="The number of classes that the model/dataset is using")
+
+    args = parser.parse_args()
+
+    assert args.mitigate ^ args.test, "Must choose only one of mitigate or test"
+
+    model = prepare_model(args.model_filepath, args.num_classes, args.device)
+    mitigation = prepare_mitigation(args)
+
+    # Mitigate a given model on a dataset that may/may not contain some mix of clean and poisoned data
+    if args.mitigate:
+        mitigate_model(model, args.dataset, args.output_dirpath)
+    # Test a model on an arbitrary dataset (either clean or poisoned)
+    elif args.test:
+        results = test_model(model, mitigation, args.dataset, args.batch_size, args.num_workers, args.device)
+        torch.save(results, os.path.join(args.output_dirpath, "results.pkl"))
+        

--- a/metaparameters.yml
+++ b/metaparameters.yml
@@ -1,0 +1,5 @@
+
+optimizer_class: "SGD"
+loss_class: "CrossEntropyLoss"
+learning_rate: 0.01
+epochs: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+configargparse
+torch
+torchvision
+tqdm
+pandas
+numpy
+torchmetrics
+opencv-python

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,0 +1,9 @@
+docker run --gpus 0 -it \
+-v /home/carnejk1/mitigation_data:/trojai-example/data/:ro \
+-v /home/carnejk1/trojai-example-mitigation/out:/trojai-example/output/:rw \
+mitigation-test \
+--test \
+--model_filepath /trojai-example/data/mitigated_model.pt \
+--dataset /trojai-example/data/dataset/clean_testset \
+--output_dirpath /trojai-example/output \
+--num_classes 10


### PR DESCRIPTION
This is a minimal example for our mitigation round code. It supports two entry points, `--mitigate` and `--test` which respectively runs the mitigation algorithm and saves, and then tests the mitigation algorithm by running inference and saving the logits. It supports a metaparameters file that is baked into the image and acts as defaults. The Dockerfile builds and runs with some caveats (see below). 

This is not 100% feature complete;
- Ideally the dataset passed in has no label available. We're creating a type of dataset that makes it easier to bookkeep what data is clean/poisoned as well as the label while also making sure that label isn't available to the container.
- This Dockerfile assumes that two APL internal dependencies are cloned and available locally; a BackdoorBox wrapper, and our latest code for the mitigation round. Currently, the code available in the private round generation repo is out of date and does not contain this baseline as well as other updates to the code
  - As an extension of this, we would like to be able to develop the mitigation round code directly in the private round generation repository, so we would need to be granted access to make branches. 